### PR TITLE
Add more tests to scheduling problem and solve them

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -30,9 +30,9 @@ public final class FindMeetingQuery {
     busyTimes = getBusyTimes(events, request);
     List<TimeRange> overlappingTimes = findOverlappingTimes();
     return (getFreeTimes(overlappingTimes, request));
-    
   }
 
+  // Compare attendees of given events with attendees for requested meeting to determine conflicts
   private List<TimeRange> getBusyTimes(Collection<Event> events, MeetingRequest request) {
 
     Collection<String> attendees = request.getAttendees();
@@ -45,6 +45,7 @@ public final class FindMeetingQuery {
     return busyTimes;
   }
 
+  // Returns list of consolidated busy time ranges accounting for overlapping events
   private List<TimeRange> findOverlappingTimes() {
     List<TimeRange> overlappingTimes = new ArrayList<>();
     int tempStartTime = -1;
@@ -69,7 +70,8 @@ public final class FindMeetingQuery {
     overlappingTimes.add(TimeRange.fromStartEnd(tempStartTime, tempEndTime, false));
     return overlappingTimes;
   }
-
+  
+  // Gets list of time slots where no attendess have any meetings >= duration time
   private Collection<TimeRange> getFreeTimes(List<TimeRange> overlappingTimes, MeetingRequest request) {
     int tempStartTime = 0;
     int tempEndTime = 0;

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -27,7 +27,6 @@ public final class FindMeetingQuery {
   List<TimeRange> freeTimes = new ArrayList<>();
 
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    //throw new UnsupportedOperationException("TODO: Implement this method.");
     busyTimes = getBusyTimes(events, request);
     List<TimeRange> overlappingTimes = findOverlappingTimes();
     return (getFreeTimes(overlappingTimes, request));
@@ -59,7 +58,7 @@ public final class FindMeetingQuery {
         tempEndTime = timeRange.end();
       }
       else if (timeRange.start() > tempEndTime) {
-        overlappingTimes.add(TimeRange.fromStartEnd(tempEndTime, tempEndTime, false));
+        overlappingTimes.add(TimeRange.fromStartEnd(tempStartTime, tempEndTime, false));
         tempStartTime = timeRange.start();
         tempEndTime = timeRange.end();
       } 
@@ -67,14 +66,11 @@ public final class FindMeetingQuery {
         ;
       }
     } 
-    if (tempStartTime != -1) {
-      overlappingTimes.add(TimeRange.fromStartEnd(tempStartTime, tempEndTime, false));
-    }
+    overlappingTimes.add(TimeRange.fromStartEnd(tempStartTime, tempEndTime, false));
     return overlappingTimes;
   }
 
   private Collection<TimeRange> getFreeTimes(List<TimeRange> overlappingTimes, MeetingRequest request) {
-    System.out.println(overlappingTimes);
     int tempStartTime = 0;
     int tempEndTime = 0;
     for (TimeRange timeRange : overlappingTimes) {

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -24,45 +24,21 @@ import java.util.Comparator;
 
 public final class FindMeetingQuery {
   List<TimeRange> busyTimes = new ArrayList<>();
+  List<TimeRange> freeTimes = new ArrayList<>();
 
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-
-    busyTimes = getBusyTimes();
-    findOverlappingTimes();
-    getFreeTimes();
     //throw new UnsupportedOperationException("TODO: Implement this method.");
-    /*Collection<String> attendees = request.getAttendees();
-    long duration = request.getDuration();
-    for (Event event : events) {
-      if(Collections.disjoint(event.getAttendees(), attendees)) {
-        busyTimes.add(event.getWhen());
-      }
-    }
-
-    Collections.sort(busyTimes, TimeRange.ORDER_BY_START);
-    int earliest = TimeRange.START_OF_DAY;
-    int index = 0;
-    Collection<TimeRange> freeTimes = new ArrayList<TimeRange>();
-    TimeRange firstStart = TimeRange.WHOLE_DAY;
-    while(index < busyTimes.size()) {
-    firstStart = busyTimes.get(index);
-    TimeRange freeTimeRange = TimeRange.fromStartEnd(earliest, firstStart.start(), false);
-  
+    busyTimes = getBusyTimes(events, request);
+    List<TimeRange> overlappingTimes = findOverlappingTimes();
+    return (getFreeTimes(overlappingTimes, request));
     
-    freeTimes.add(freeTimeRange);
-    int endTime = firstStart.end(); 
-    index++;
-    earliest = endTime;
-    firstStart = busyTimes.get(index);
-    }
-    freeTimes.add(TimeRange.fromStartEnd(firstStart.start(), TimeRange.END_OF_DAY, true));
-    return freeTimes;*/
   }
 
   private List<TimeRange> getBusyTimes(Collection<Event> events, MeetingRequest request) {
-    Collection<String> attendees = getAttendees;
+
+    Collection<String> attendees = request.getAttendees();
     for (Event event : events) {
-      if(Collections.disjoint(event.getAttendees(), attendees)) {
+      if(!(Collections.disjoint(event.getAttendees(), attendees))) {
         busyTimes.add(event.getWhen());
       }
     }
@@ -72,10 +48,10 @@ public final class FindMeetingQuery {
 
   private List<TimeRange> findOverlappingTimes() {
     List<TimeRange> overlappingTimes = new ArrayList<>();
-    int tempStartTime = 0;
+    int tempStartTime = -1;
     int tempEndTime = 0;
     for (TimeRange timeRange : busyTimes) {
-      if (tempStartTime == 0) {
+      if (tempStartTime == -1) {
         tempStartTime = timeRange.start();
         tempEndTime = timeRange.end();
       }
@@ -83,7 +59,7 @@ public final class FindMeetingQuery {
         tempEndTime = timeRange.end();
       }
       else if (timeRange.start() > tempEndTime) {
-        fromStartEnd(tempEndTime, tempEndTime, false);
+        overlappingTimes.add(TimeRange.fromStartEnd(tempEndTime, tempEndTime, false));
         tempStartTime = timeRange.start();
         tempEndTime = timeRange.end();
       } 
@@ -91,10 +67,31 @@ public final class FindMeetingQuery {
         ;
       }
     } 
-
+    if (tempStartTime != -1) {
+      overlappingTimes.add(TimeRange.fromStartEnd(tempStartTime, tempEndTime, false));
+    }
+    return overlappingTimes;
   }
 
-  private Collection<TimeRange> getFreeTimes() {
-
+  private Collection<TimeRange> getFreeTimes(List<TimeRange> overlappingTimes, MeetingRequest request) {
+    System.out.println(overlappingTimes);
+    int tempStartTime = 0;
+    int tempEndTime = 0;
+    for (TimeRange timeRange : overlappingTimes) {
+      if (timeRange.start() == 0) {
+        tempStartTime = timeRange.end();
+      }
+      else {
+        tempEndTime = timeRange.start();
+        if ((tempEndTime - tempStartTime) >= request.getDuration()) { 
+          freeTimes.add(TimeRange.fromStartEnd(tempStartTime, tempEndTime, false));
+        }
+        tempStartTime = timeRange.end();
+      }
+    }
+    if ((TimeRange.END_OF_DAY - tempStartTime) >= request.getDuration()) { 
+      freeTimes.add(TimeRange.fromStartEnd(tempStartTime, TimeRange.END_OF_DAY, true));
+    }
+    return freeTimes;
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -14,10 +14,87 @@
 
 package com.google.sps;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.LinkedList;
+import java.util.Comparator;
 
 public final class FindMeetingQuery {
+  List<TimeRange> busyTimes = new ArrayList<>();
+
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    throw new UnsupportedOperationException("TODO: Implement this method.");
+
+    busyTimes = getBusyTimes();
+    findOverlappingTimes();
+    getFreeTimes();
+    //throw new UnsupportedOperationException("TODO: Implement this method.");
+    /*Collection<String> attendees = request.getAttendees();
+    long duration = request.getDuration();
+    for (Event event : events) {
+      if(Collections.disjoint(event.getAttendees(), attendees)) {
+        busyTimes.add(event.getWhen());
+      }
+    }
+
+    Collections.sort(busyTimes, TimeRange.ORDER_BY_START);
+    int earliest = TimeRange.START_OF_DAY;
+    int index = 0;
+    Collection<TimeRange> freeTimes = new ArrayList<TimeRange>();
+    TimeRange firstStart = TimeRange.WHOLE_DAY;
+    while(index < busyTimes.size()) {
+    firstStart = busyTimes.get(index);
+    TimeRange freeTimeRange = TimeRange.fromStartEnd(earliest, firstStart.start(), false);
+  
+    
+    freeTimes.add(freeTimeRange);
+    int endTime = firstStart.end(); 
+    index++;
+    earliest = endTime;
+    firstStart = busyTimes.get(index);
+    }
+    freeTimes.add(TimeRange.fromStartEnd(firstStart.start(), TimeRange.END_OF_DAY, true));
+    return freeTimes;*/
+  }
+
+  private List<TimeRange> getBusyTimes(Collection<Event> events, MeetingRequest request) {
+    Collection<String> attendees = getAttendees;
+    for (Event event : events) {
+      if(Collections.disjoint(event.getAttendees(), attendees)) {
+        busyTimes.add(event.getWhen());
+      }
+    }
+    Collections.sort(busyTimes, TimeRange.ORDER_BY_START);
+    return busyTimes;
+  }
+
+  private List<TimeRange> findOverlappingTimes() {
+    List<TimeRange> overlappingTimes = new ArrayList<>();
+    int tempStartTime = 0;
+    int tempEndTime = 0;
+    for (TimeRange timeRange : busyTimes) {
+      if (tempStartTime == 0) {
+        tempStartTime = timeRange.start();
+        tempEndTime = timeRange.end();
+      }
+      else if ((timeRange.start() <= tempEndTime) && (timeRange.end() >= tempEndTime)){
+        tempEndTime = timeRange.end();
+      }
+      else if (timeRange.start() > tempEndTime) {
+        fromStartEnd(tempEndTime, tempEndTime, false);
+        tempStartTime = timeRange.start();
+        tempEndTime = timeRange.end();
+      } 
+      else {
+        ;
+      }
+    } 
+
+  }
+
+  private Collection<TimeRange> getFreeTimes() {
+
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -388,3 +388,4 @@ public final class FindMeetingQueryTest {
             
     Assert.assertEquals(expected, actual);
   }
+}


### PR DESCRIPTION
In this pull request I created 5 new tests for the calendar scheduling algorithm that were described in the walkthrough (see comments above each test function). These test have to do with including optional attendees when considering meeting times. I used the structure from the given tests to construct my own. 

I also changed the FindMeetingQuery.java file to pass these new tests. Essentially, I run the algorithm as before with both mandatory and optional attendees. Then, I see if the list of available times is empty. If it is, I rerun through the algorithm with just the mandatory attendees and return that value. 

If I have more time, I will try to optimize this algorithm further! Thanks.